### PR TITLE
Upgrade to v0.9.46

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It shall NOT be edited by hand.
 Bring projects, wikis, and teams together with AI
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](https://appflowy.io/)
-[![Version: 0.9.46~ynh1](https://img.shields.io/badge/Version-0.9.46~ynh1-rgba(0,150,0,1)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/appflowy/)
+[![Version: 0.9.47~ynh1](https://img.shields.io/badge/Version-0.9.47~ynh1-rgba(0,150,0,1)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/appflowy/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/appflowy"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It shall NOT be edited by hand.
 Bring projects, wikis, and teams together with AI
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](https://appflowy.io/)
-[![Version: 0.9.44~ynh1](https://img.shields.io/badge/Version-0.9.44~ynh1-rgba(0,150,0,1)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/appflowy/)
+[![Version: 0.9.46~ynh1](https://img.shields.io/badge/Version-0.9.46~ynh1-rgba(0,150,0,1)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/appflowy/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/appflowy"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/manifest.toml
+++ b/manifest.toml
@@ -6,7 +6,7 @@ id = "appflowy"
 name = "AppFlowy"
 description.en = "Bring projects, wikis, and teams together with AI"
 
-version = "0.9.46~ynh1"
+version = "0.9.47~ynh1"
 
 maintainers = ["yalh76"]
 
@@ -59,8 +59,8 @@ ram.runtime = "50M"
     # This will pre-fetch the asset which can then be deployed during the install/upgrade scripts with :
     #    ynh_setup_source --dest_dir="$install_dir"
     # You can also define other assets than "main" and add --source_id="foobar" in the previous command
-    url = "https://github.com/AppFlowy-IO/AppFlowy-Cloud/archive/refs/tags/0.9.46.tar.gz"
-    sha256 = "5bf9e652c430dee53acb073765e93e150a2f6b83cb4a234530757e3d050b18f9"
+    url = "https://github.com/AppFlowy-IO/AppFlowy-Cloud/archive/refs/tags/0.9.47.tar.gz"
+    sha256 = "17daee97183b470dce983a28b19e827826d88d730aedf6a144b4f2bbf84ad899"
     prefetch = false
     autoupdate.strategy = "latest_github_tag"
     

--- a/manifest.toml
+++ b/manifest.toml
@@ -6,7 +6,7 @@ id = "appflowy"
 name = "AppFlowy"
 description.en = "Bring projects, wikis, and teams together with AI"
 
-version = "0.9.44~ynh1"
+version = "0.9.46~ynh1"
 
 maintainers = ["yalh76"]
 
@@ -59,8 +59,8 @@ ram.runtime = "50M"
     # This will pre-fetch the asset which can then be deployed during the install/upgrade scripts with :
     #    ynh_setup_source --dest_dir="$install_dir"
     # You can also define other assets than "main" and add --source_id="foobar" in the previous command
-    url = "https://github.com/AppFlowy-IO/AppFlowy-Cloud/archive/refs/tags/0.9.44.tar.gz"
-    sha256 = "401e508cd7ce35df875bafc83cb0cfebbd322411f26c9fb726e99c0d684c619a"
+    url = "https://github.com/AppFlowy-IO/AppFlowy-Cloud/archive/refs/tags/0.9.46.tar.gz"
+    sha256 = "5bf9e652c430dee53acb073765e93e150a2f6b83cb4a234530757e3d050b18f9"
     prefetch = false
     autoupdate.strategy = "latest_github_tag"
     


### PR DESCRIPTION
Upgrade sources
- `main` v0.9.46: https://github.com/AppFlowy-IO/AppFlowy-Cloud/releases/tag/0.9.46

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
